### PR TITLE
Task uplift

### DIFF
--- a/.github/workflows/BuildAndTestOnEveryPush.yml
+++ b/.github/workflows/BuildAndTestOnEveryPush.yml
@@ -25,4 +25,4 @@ jobs:
       run: dotnet pack --configuration Release --include-source
       
     - name: Push NuGet package to the testfeed
-      run: dotnet nuget push Frends.Community.Multipart\bin\Release\Frends.Community.Multipart.*.nupkg  --api-key ${{ secrets.COMMUNITY_FEED_API_KEY }} --source https://www.myget.org/F/frends-community-test/api/v2/package --symbol-source https://www.myget.org/F/frends-community-test/symbols/api/v2/package
+      run: dotnet nuget push Frends.Community.Multipart\bin\Release\Frends.Community.Multipart.*.nupkg  --api-key ${{ secrets.COMMUNITY_FEED_API_KEY }} --source https://www.myget.org/F/frends-community-test/api/v2/package

--- a/Frends.Community.Multipart/Frends.Community.Multipart.csproj
+++ b/Frends.Community.Multipart/Frends.Community.Multipart.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
+	<TargetFrameworks>netstandard2.0;net471;net6.0;net8.0</TargetFrameworks>
     <authors>HiQ Finland</authors>
     <copyright>HiQ Finland</copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -10,7 +10,7 @@
     <PackageTags>Frends</PackageTags>
 	<Description>A frends task for parsing multipart/form-data messages.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.0.0</Version>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,10 +20,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HttpMultipartParser" Version="4.3.1" />
+    <PackageReference Include="HttpMultipartParser" Version="5.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
 </Project>
-

--- a/README.md
+++ b/README.md
@@ -140,3 +140,4 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | Version | Changes |
 | ------- | ------- |
 | 1.0.0   | Inital release of task. |
+| 2.0.0   | Targeted to .NET6 and 8, and updated System.ComponentModel.Annotations to 5.0.0 and HttpMultipartParser to 5.0.1. |


### PR DESCRIPTION
Targeted to .NET6 and 8 and updated System.ComponentModel.Annotations to 5.0.0 and HttpMultipartParser to 5.0.1.

Not tested on Frends separately, but unit tests pass.